### PR TITLE
Error correction in 7TV

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ export default class TwitchFetcher {
       const fixedEmotes: Emote[] = providerEmotes.map((emote) => ({
         code: emote.name,
         id: emote.id,
-        owner: emote.data.owner.username,
+        owner: emote.data.owner?.username,
         type: '7tv',
         url: {
           low: `${emote.data.host.url}/${emote.data.host.files[0].name}`,


### PR DESCRIPTION
This fix prevents an error in 7TV when the emote does not have owner.

![image](https://github.com/sammwyy/twitch-fetcher/assets/57513632/c77f31d3-55bc-406d-94d1-dfad599f1f88)
